### PR TITLE
add key_value_mask argument for cross attention

### DIFF
--- a/h_transformer_1d/__init__.py
+++ b/h_transformer_1d/__init__.py
@@ -1,1 +1,2 @@
 from h_transformer_1d.h_transformer_1d import HTransformer1D
+from h_transformer_1d.h_transformer_1d import HAttention1D


### PR DESCRIPTION
This change set enables the use of two different masks for queries and keys/values. This is necessary for using the module as a cross attention.